### PR TITLE
feat(wiki): maintenance guidance and cross-repo reading

### DIFF
--- a/plugins/simpleapps/commands/wiki.md
+++ b/plugins/simpleapps/commands/wiki.md
@@ -1,12 +1,17 @@
 ---
 name: wiki
 description: Load the project wiki into context for reference and assistance
-allowed-tools: Read, Glob
+allowed-tools: Read, Glob, Bash(gh api:*), Bash(gh repo:*)
 ---
 
-Load the entire project wiki into your context so you can answer questions and assist with the current project.
+Load a wiki into your context so you can answer questions and assist with the project.
 
-## Steps
+## Determine mode
+
+- **No arguments** → load the local wiki from the filesystem (`wiki/`)
+- **Argument provided** → load a remote wiki via GitHub API
+
+## Local wiki (no arguments)
 
 1. Read `wiki/Home.md` first to orient on the project
 2. Read `wiki/llms.txt` to get the wiki index and file summaries
@@ -14,9 +19,21 @@ Load the entire project wiki into your context so you can answer questions and a
 4. Read every `.md` file using the Read tool — do NOT use a subagent, the content MUST be in your own context
 5. After loading, confirm which files were loaded and ask the user how you can help
 
+## Remote wiki (argument provided)
+
+The argument is a repo name. If it contains `/`, use it as `org/repo`. Otherwise, default to `simpleapps-com/<name>`.
+
+1. List wiki pages: `gh api repos/<org>/<repo>/wiki/pages --paginate 2>/dev/null` — if this fails, try cloning:
+   - `gh api repos/<org>/<repo>/contents` and look for wiki indicators, OR
+   - Inform the user the wiki is not accessible via API and suggest cloning it locally
+2. For each page returned, fetch its content via the API
+3. If the API approach fails, try: `gh repo clone <org>/<repo>.wiki /tmp/<repo>-wiki -- --depth 1` then read the files locally and clean up when done
+4. After loading, confirm which pages were loaded and ask the user how you can help
+
 ## Important
 
-- Use the Read tool, NOT `cat` or other Bash commands
-- Use Glob, NOT `find` or `ls`
+- Use the Read tool, NOT `cat` or other Bash commands for local files
+- Use Glob, NOT `find` or `ls` for local files
 - Do NOT skip any wiki files — load them all
 - If `wiki/llms.txt` does not exist, skip it and proceed with the glob
+- Remote wikis: prefer the API, fall back to shallow clone if needed

--- a/plugins/simpleapps/commands/wiki.md
+++ b/plugins/simpleapps/commands/wiki.md
@@ -1,7 +1,7 @@
 ---
 name: wiki
 description: Load the project wiki into context for reference and assistance
-allowed-tools: Read, Glob, Bash(gh api:*), Bash(gh repo:*)
+allowed-tools: Read, Glob, Bash(gh repo clone:*), Bash(rm -rf /tmp/*-wiki:*)
 ---
 
 Load a wiki into your context so you can answer questions and assist with the project.
@@ -9,7 +9,7 @@ Load a wiki into your context so you can answer questions and assist with the pr
 ## Determine mode
 
 - **No arguments** → load the local wiki from the filesystem (`wiki/`)
-- **Argument provided** → load a remote wiki via GitHub API
+- **Argument provided** → shallow-clone the remote wiki to `/tmp/`, read it, then clean up
 
 ## Local wiki (no arguments)
 
@@ -23,17 +23,17 @@ Load a wiki into your context so you can answer questions and assist with the pr
 
 The argument is a repo name. If it contains `/`, use it as `org/repo`. Otherwise, default to `simpleapps-com/<name>`.
 
-1. List wiki pages: `gh api repos/<org>/<repo>/wiki/pages --paginate 2>/dev/null` — if this fails, try cloning:
-   - `gh api repos/<org>/<repo>/contents` and look for wiki indicators, OR
-   - Inform the user the wiki is not accessible via API and suggest cloning it locally
-2. For each page returned, fetch its content via the API
-3. If the API approach fails, try: `gh repo clone <org>/<repo>.wiki /tmp/<repo>-wiki -- --depth 1` then read the files locally and clean up when done
-4. After loading, confirm which pages were loaded and ask the user how you can help
+1. Shallow-clone the wiki repo: `gh repo clone <org>/<repo>.wiki /tmp/<repo>-wiki -- --depth 1`
+2. Read `/tmp/<repo>-wiki/Home.md` first to orient
+3. Use Glob to find all `*.md` files in `/tmp/<repo>-wiki/`
+4. Read every `.md` file using the Read tool — do NOT use a subagent, the content MUST be in your own context
+5. Delete the temp clone: `rm -rf /tmp/<repo>-wiki`
+6. After loading, confirm which pages were loaded and ask the user how you can help
 
 ## Important
 
-- Use the Read tool, NOT `cat` or other Bash commands for local files
-- Use Glob, NOT `find` or `ls` for local files
+- Use the Read tool, NOT `cat` or other Bash commands
+- Use Glob, NOT `find` or `ls`
 - Do NOT skip any wiki files — load them all
-- If `wiki/llms.txt` does not exist, skip it and proceed with the glob
-- Remote wikis: prefer the API, fall back to shallow clone if needed
+- If `llms.txt` does not exist, skip it and proceed with the glob
+- Remote wikis are read-only — all content lives in agent context after loading, nothing persists on disk

--- a/plugins/simpleapps/skills/github/SKILL.md
+++ b/plugins/simpleapps/skills/github/SKILL.md
@@ -25,6 +25,7 @@ If `git push` fails with 401/403, run `gh auth setup-git` to fix credentials.
 ## Key Topics
 
 - **Wiki as context** — See `wiki-as-context.md` for why the wiki is the source of truth and how to write for both humans and AI agents.
+- **Wiki maintenance** — See `wiki-maintenance.md` for how to verify, update, and maintain wiki content correctly.
 - **Project structure** — See `project-structure.md` for the `{project}/[repo|wiki]` layout, what goes where, and wiki conventions.
 - **Issues & pull requests** — See `issues-prs.md` for issue templates, PR commands, and cross-linking with Basecamp.
 

--- a/plugins/simpleapps/skills/github/wiki-as-context.md
+++ b/plugins/simpleapps/skills/github/wiki-as-context.md
@@ -110,24 +110,23 @@ This matters for two reasons:
 - **Devs** jump straight to the answer instead of scrolling through a page
 - **AI agents** use anchor links as an attention signal — a `#section` reference tells the agent exactly which part of a page is relevant to the current task, reducing noise in a 20K token wiki
 
-### The 20K Token Budget
+### Keep It Lean
 
-The entire wiki MUST stay under **20K tokens** (~60KB of markdown). This is a hard constraint, not a guideline.
+Wikis SHOULD be as small as possible while remaining complete. The goal: an AI agent can load the **entire wiki** into context at session start and keep it there throughout.
 
-Why 20K: with a 200K token context window, the full wiki never exceeds 10% of available context. This means an AI agent can load the **entire wiki** into active context at the start of a session and keep it there throughout. No selective loading, no missed context, no stale references — the agent always has the complete picture.
-
-If the wiki approaches the budget:
+Guidelines:
 - Tighten language — cut filler, use tables over prose
 - Merge overlapping pages
-- Move implementation details back to code comments where they belong
+- Document patterns and principles, not exhaustive implementation details (see `wiki-maintenance.md`)
 - Archive obsolete pages (delete, don't hoard)
+- Move implementation specifics back to code comments where they belong
 
-To check the current budget:
+To check wiki size:
 ```bash
 wc -c {project}/wiki/*.md
 ```
 
-Rough conversion: 1 token ≈ 3 bytes of markdown. So 20K tokens ≈ 60KB.
+Rough conversion: 1 token ≈ 3 bytes of markdown.
 
 ### Right-Size Each Page
 

--- a/plugins/simpleapps/skills/github/wiki-maintenance.md
+++ b/plugins/simpleapps/skills/github/wiki-maintenance.md
@@ -1,0 +1,71 @@
+# Wiki Maintenance
+
+Guidance for agents editing wiki content. Applies to all `wiki/*.md` files across all projects.
+
+## Verify Before You Write
+
+Cross-check wiki claims against the codebase before updating. Staleness-prone sections:
+
+- Package versions (`package.json` is the source of truth)
+- File counts and file inventories (files get added/deleted)
+- CI/CD workflow status (workflows get added/modified)
+- TODO items and "not yet built" markers (things get done)
+- Export lists and API surfaces (code changes)
+
+**Never echo what the wiki already says.** Read the code, then write the wiki.
+
+## Patterns, Not Details
+
+The wiki documents **conventions and principles**. The code is the source of truth for specifics.
+
+- No hardcoded counts ("22 components", "14 hooks" — these change)
+- No exhaustive lists of every type, hook, component, or export by name
+- No pinned version numbers for peer dependencies
+- Instead: describe the pattern, give 1-2 examples, point to source code for the current list
+
+## Naming Conventions
+
+Follow the project's existing convention:
+
+- **Site wikis**: PascalCase with hyphens (`Getting-Started.md`, `Architecture.md`)
+- **Package wikis**: Prefix-based sections (`guide-*.md` for users, `design-*.md` for contributors)
+
+Check `Home.md` or `_Sidebar.md` to confirm the convention before creating new pages.
+
+## Keep Indexes Current
+
+When adding or removing pages, MUST update:
+
+- `Home.md` / `README.md` (index tables)
+- `_Sidebar.md` (navigation)
+- `llms.txt` (if present)
+
+## Tagging for Lead-Site Wikis
+
+The lead site wiki (e.g., ampro-online) serves as both site documentation and platform reference. Tag sections:
+
+- **(platform pattern)** — guidance all sites SHOULD follow
+- **(site-specific)** — this site's particular values, replace with your own
+
+This tells agents working on other sites what to replicate vs customize.
+
+## Dual-Audience Framing
+
+Lead site wikis serve two audiences:
+
+1. Developers/agents working on **that site**
+2. Developers/agents building or migrating **other sites**
+
+Write for both: document current reality AND provide guidance others can follow.
+
+## Git Workflow
+
+The wiki is a separate git repo at `wiki/`. No branch protection, no PRs, no changesets.
+
+```bash
+git -C wiki add -A
+git -C wiki commit -m "docs: describe the change"
+git -C wiki push
+```
+
+Wiki repos typically use `master` as the default branch.


### PR DESCRIPTION
## Summary

- **New: `wiki-maintenance.md`** — teaches agents how to maintain wikis correctly: verify before writing, document patterns not details, keep indexes current, tag lead-site content as `(platform pattern)` vs `(site-specific)`, dual-audience framing
- **Updated: `/wiki` command** — accepts optional repo name arg (`/wiki augur-packages`) to load a remote wiki via `gh` API, defaults to `simpleapps-com` org
- **Updated: `wiki-as-context.md`** — softened 20K token hard limit to a SHOULD guideline, linked to maintenance doc

Closes #21, closes #22

## Test plan

- [ ] Run `/wiki` with no args in a project with a local wiki — should work as before
- [ ] Run `/wiki augur-packages` from a different project — should load remote wiki via gh API
- [ ] Verify `wiki-maintenance.md` loads when github skill activates
- [ ] Confirm CLI skills copy stays in sync after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)