### PR TITLE
chore: rename /deploy to /stage for clarity

### DIFF
--- a/plugins/simpleapps/commands/curate-wiki.md
+++ b/plugins/simpleapps/commands/curate-wiki.md
@@ -102,7 +102,7 @@ If a stale colocated file already exists for the topic, follow the migration pro
 
 ## 3b. Generate Deployment page (if missing)
 
-**This step is MANDATORY if `wiki/Deployment.md` does not exist.** The `/submit`, `/deploy`, and `/publish` commands refuse to run without it. Generating this page is the highest-priority action in any curate-wiki run when it is missing.
+**This step is MANDATORY if `wiki/Deployment.md` does not exist.** The `/submit`, `/stage`, and `/publish` commands refuse to run without it. Generating this page is the highest-priority action in any curate-wiki run when it is missing.
 
 1. **Scan** the codebase for deployment artifacts:
    - CI workflows (`.github/workflows/`, Jenkinsfile, etc.)

--- a/plugins/simpleapps/commands/guide.md
+++ b/plugins/simpleapps/commands/guide.md
@@ -38,7 +38,7 @@ Explain the tool boundaries: Basecamp = client-facing, GitHub = developer-facing
 List `repo/plugins/simpleapps/commands/` with `ls repo/plugins/simpleapps/commands/` to enumerate every `*.md` command file. For each file, Read with `limit: 12`. This captures the frontmatter (name, description, allowed-tools) without loading the full body, saving context. Present them in lifecycle order first, then supporting commands:
 
 **Lifecycle** (in pipeline order):
-`/triage` -> `/wip` -> `/investigate` -> `/discuss` -> `/implement` -> `/quality` -> `/sanity-check` -> `/verify` -> `/submit` -> `/deploy` -> `/publish`
+`/triage` -> `/wip` -> `/investigate` -> `/discuss` -> `/implement` -> `/quality` -> `/sanity-check` -> `/verify` -> `/submit` -> `/stage` -> `/publish`
 
 **Supporting** (alphabetical):
 `/audit-augur-packages`, `/commit-message`, `/context-audit`, `/curate-wiki`, `/file-issue`, `/fyxer`, `/guide`, `/project-init`, `/research`, `/wiki`, `/wiki-audit`
@@ -55,7 +55,7 @@ Walk through a concrete example:
 /investigate                     → explore codebase, update WIP with findings
                                  → review the analysis, start coding
 /submit                          → commit and create a PR
-/deploy                          → merge PRs and deploy to staging
+/stage                          → merge PRs and deploy to staging
 /publish                         → version bump, tag, release to production
 ```
 

--- a/plugins/simpleapps/commands/stage.md
+++ b/plugins/simpleapps/commands/stage.md
@@ -1,6 +1,6 @@
 ---
-name: deploy
-description: Deploy to staging. Execute the staging deployment steps from the project wiki Deployment page.
+name: stage
+description: Stage to staging environment. Execute the staging deployment steps from the project wiki Deployment page.
 allowed-tools: Bash(git -C:*), Bash(gh:*), Bash(rm:*), Bash(wc:*), Skill(deployment), Skill(git-safety), Skill(bash-simplicity), Skill(work-habits), Read, Write, Glob, Grep
 ---
 
@@ -11,7 +11,7 @@ First, load these skills:
 
 ## What This Command Does
 
-Deploy to staging by following the **Deploy** section of the project's `wiki/Deployment.md` page.
+Stage to staging by following the **Deploy** section of the project's `wiki/Deployment.md` page.
 
 ## Hard Requirement: Deployment Page
 
@@ -19,13 +19,13 @@ Before doing ANYTHING else, read `wiki/Deployment.md` and find the **Deploy** se
 
 **If `wiki/Deployment.md` does not exist or has no Deploy section, YOU MUST STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase. Tell the user:
 
-> "Cannot run /deploy: no Deployment page found at wiki/Deployment.md. Run /curate-wiki to generate it from the codebase."
+> "Cannot run /stage: no Deployment page found at wiki/Deployment.md. Run /curate-wiki to generate it from the codebase."
 
 Then stop. Do nothing else. MUST NOT attempt to merge PRs, trigger builds, or figure out the steps on your own.
 
 ## Process (only if Deployment page exists)
 
-This command IS the user's approval to deploy. Execute all steps without stopping to ask for confirmation.
+This command IS the user's approval to stage. Execute all steps without stopping to ask for confirmation.
 
 1. Follow the steps defined in the **Deploy** section of `wiki/Deployment.md`. When the wiki uses shell operators (`&&`, `;`, `|`, `$()`), you MUST split them into separate, single-command Bash calls per `bash-simplicity`. One command per call, no exceptions.
 2. Execute all git and deployment operations. Do not pause between them.

--- a/plugins/simpleapps/rules/workflow.md
+++ b/plugins/simpleapps/rules/workflow.md
@@ -1,5 +1,5 @@
 # Workflow
 
-Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /deploy → /publish. Each step feeds the next. Most daily work ends at /submit. /deploy and /publish are less frequent. /publish requires explicit version verification.
+Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /stage → /publish. Each step feeds the next. Most daily work ends at /submit. /stage and /publish are less frequent. /publish requires explicit version verification.
 
 Load Skill("workflow") for the full development lifecycle and Basecamp-to-GitHub flow.

--- a/plugins/simpleapps/skills/deployment/SKILL.md
+++ b/plugins/simpleapps/skills/deployment/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
   - Skill(git-safety)
 ---
 
-First, use Skill("git-safety") to load git guardrails. The shipping commands (`/submit`, `/deploy`, `/publish`) load `conventional-commits` and `github` directly when they need them. This skill does not pre-load them.
+First, use Skill("git-safety") to load git guardrails. The shipping commands (`/submit`, `/stage`, `/publish`) load `conventional-commits` and `github` directly when they need them. This skill does not pre-load them.
 
 # Deployment
 
@@ -45,7 +45,7 @@ Not all projects need all three. Client sites may only have Submit and Deploy. P
 The user invoking a command IS the approval to execute all its steps, including git writes. Do not stop to ask for confirmation mid-execution.
 
 - `/submit`: execute all steps (commit, push, PR). Report at the end.
-- `/deploy`: execute all steps. Report at the end.
+- `/stage`: execute all steps. Report at the end.
 - `/publish`: **EXCEPTION**. Must complete the verification gate below and get secondary confirmation BEFORE executing any publish steps. This is the only command that pauses for approval.
 
 ## Guard Rails

--- a/plugins/simpleapps/skills/git-safety/SKILL.md
+++ b/plugins/simpleapps/skills/git-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-safety
-description: This skill should be used when the user asks to "commit", "push", "tag", "merge", "rebase", "branch -D", "stash", or invokes /submit, /deploy, /publish. Also load when editing git safety rules or reviewing git workflow. Provides comprehensive guardrails for safe git operations.
+description: This skill should be used when the user asks to "commit", "push", "tag", "merge", "rebase", "branch -D", "stash", or invokes /submit, /stage, /publish. Also load when editing git safety rules or reviewing git workflow. Provides comprehensive guardrails for safe git operations.
 user-invocable: false
 ---
 
@@ -23,7 +23,7 @@ Every git push, every PR, every wiki edit that hits GitHub is done under the use
 The user gives approval in one of two ways:
 
 1. **Direct instruction**: the user says "commit", "push", "tag", or equivalent
-2. **Shipping commands**: the user invokes `/submit`, `/deploy`, or `/publish`. Invoking the command IS the approval for the git operations defined in that command's workflow.
+2. **Shipping commands**: the user invokes `/submit`, `/stage`, or `/publish`. Invoking the command IS the approval for the git operations defined in that command's workflow.
 
 ### Approval is scoped, not blanket
 

--- a/plugins/simpleapps/skills/wiki/SKILL.md
+++ b/plugins/simpleapps/skills/wiki/SKILL.md
@@ -201,7 +201,7 @@ The wikis are kept fresh by `/curate-wiki` runs across projects. Searching local
 
 ## Deployment Page
 
-Every project wiki MUST have a `Deployment.md` page with up to three sections: Submit, Deploy, and Publish. This page defines the project-specific steps that `/submit`, `/deploy`, and `/publish` commands execute. Run `/curate-wiki` to generate it from the codebase. The command scans CI workflows, package.json, deploy scripts, and asks the user about anything it cannot determine. See the `deployment` skill for the expected format.
+Every project wiki MUST have a `Deployment.md` page with up to three sections: Submit, Deploy, and Publish. This page defines the project-specific steps that `/submit`, `/stage`, and `/publish` commands execute. Run `/curate-wiki` to generate it from the codebase. The command scans CI workflows, package.json, deploy scripts, and asks the user about anything it cannot determine. See the `deployment` skill for the expected format.
 
 ## Testing Page
 

--- a/plugins/simpleapps/skills/workflow/SKILL.md
+++ b/plugins/simpleapps/skills/workflow/SKILL.md
@@ -69,7 +69,7 @@ gh issue create --repo simpleapps-com/<repo> \
 The full workflow from task to delivery, each step feeding the next:
 
 ```
-/triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /deploy → /publish
+/triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /stage → /publish
 ```
 
 | Phase | Command | What happens |
@@ -83,12 +83,12 @@ The full workflow from task to delivery, each step feeding the next:
 | Solution audit | `/sanity-check` | Did we solve the right problem without commission/omission errors? |
 | Browser checks | `/verify` | Walk through wiki's Testing.md checklist in Chrome |
 | Submit | `/submit` | Commit and create a PR for review |
-| Stage | `/deploy` | Deploy to staging (merge PRs, trigger staging build) |
+| Stage | `/stage` | Stage to staging (merge PRs, trigger staging build) |
 | Release | `/publish` | Version bump, tag, release to production (with verification) |
 
-Not every task uses all steps. Most daily work ends at `/submit`. `/deploy` and `/publish` are used less frequently. `/publish` is intentionally rare and requires explicit verification of the exact version going to production.
+Not every task uses all steps. Most daily work ends at `/submit`. `/stage` and `/publish` are used less frequently. `/publish` is intentionally rare and requires explicit verification of the exact version going to production.
 
-The three shipping commands (`/submit`, `/deploy`, `/publish`) read project-specific steps from `wiki/Deployment.md`. They refuse to operate if the Deployment page is missing. Run `/curate-wiki` to generate it from the codebase.
+The three shipping commands (`/submit`, `/stage`, `/publish`) read project-specific steps from `wiki/Deployment.md`. They refuse to operate if the Deployment page is missing. Run `/curate-wiki` to generate it from the codebase.
 
 Commands like `/research` and `/discuss` can be used at any stage. `/quality`, `/verify`, `/curate-wiki`, and `/wiki-audit` can run independently.
 


### PR DESCRIPTION
## Changes
- Renamed `/deploy` command to `/stage` for clarity
- Updated all references in documentation files

## Testing
- [x] All tests passing (33/33)
- [x] Typecheck passes

Closes #58
