### PR TITLE
chore: rename /deploy to /stage and fix context compaction

### DIFF
--- a/.claude/rules/bash-simplicity.md
+++ b/.claude/rules/bash-simplicity.md
@@ -1,5 +1,7 @@
 # Bash Simplicity
 
+**Always prefer dedicated tools over Bash.** Use Read, Edit, or Write first. Only use Bash for search, build, test, git, and system commands.
+
 The Bash tool already captures stdout, stderr, and exit codes. NEVER add shell plumbing — no `;`, `&&`, `|`, `$()`, `2>&1`, `echo $?`, `node -e`, or `python -c`. If the command contains any of these, it is wrong. One command per call.
 
 MUST use dedicated tools instead of shell commands — including when searching other projects:
@@ -7,6 +9,7 @@ MUST use dedicated tools instead of shell commands — including when searching 
 - Find files → Glob tool (not `find`, `ls`)
 - Read files → Read tool (not `cat`, `head`, `tail`)
 - Edit files → Edit tool (not `sed`, `awk`)
+- JSON field extraction → `jq '.field' file.json`
 
 MUST NOT use `kill`, `pkill`, or `lsof` to stop processes. Use TaskStop with the task ID instead. TaskStop cleanly shuts down background tasks (dev servers, watchers) and updates internal tracking. If the process was started outside your session, ask the user to stop it.
 

--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -1,5 +1,5 @@
 # Workflow
 
-Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /verify → /submit → /deploy → /publish. Each step feeds the next. Most daily work ends at /submit. /deploy and /publish are less frequent — /publish requires explicit version verification.
+Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /verify → /submit → /stage → /publish. Each step feeds the next. Most daily work ends at /submit. /stage and /publish are less frequent — /publish requires explicit version verification.
 
 Load Skill("workflow") for the full development lifecycle and Basecamp-to-GitHub flow.

--- a/plugins/simpleapps/commands/curate-wiki.md
+++ b/plugins/simpleapps/commands/curate-wiki.md
@@ -102,7 +102,7 @@ If a stale colocated file already exists for the topic, follow the migration pro
 
 ## 3b. Generate Deployment page (if missing)
 
-**This step is MANDATORY if `wiki/Deployment.md` does not exist.** The `/submit`, `/deploy`, and `/publish` commands refuse to run without it. Generating this page is the highest-priority action in any curate-wiki run when it is missing.
+**This step is MANDATORY if `wiki/Deployment.md` does not exist.** The `/submit`, `/stage`, and `/publish` commands refuse to run without it. Generating this page is the highest-priority action in any curate-wiki run when it is missing.
 
 1. **Scan** the codebase for deployment artifacts:
    - CI workflows (`.github/workflows/`, Jenkinsfile, etc.)

--- a/plugins/simpleapps/commands/deploy.md
+++ b/plugins/simpleapps/commands/deploy.md
@@ -1,32 +1,9 @@
 ---
 name: deploy
-description: Deploy to staging. Execute the staging deployment steps from the project wiki Deployment page.
-allowed-tools: Bash(git -C:*), Bash(gh:*), Bash(rm:*), Bash(wc:*), Skill(deployment), Skill(git-safety), Skill(bash-simplicity), Skill(work-habits), Read, Write, Glob, Grep
+description: DEPRECATED. Use /stage instead.
+allowed-tools: None
 ---
 
-First, load these skills:
-1. Skill("deployment"): reads wiki Deployment page and loads git-safety
-2. Skill("bash-simplicity"): Bash conventions
-3. Skill("work-habits"): autonomous execution rules and RFC 2119 compliance
+**DEPRECATED:** This command has been renamed to `/stage`.
 
-## What This Command Does
-
-Deploy to staging by following the **Deploy** section of the project's `wiki/Deployment.md` page.
-
-## Hard Requirement: Deployment Page
-
-Before doing ANYTHING else, read `wiki/Deployment.md` and find the **Deploy** section.
-
-**If `wiki/Deployment.md` does not exist or has no Deploy section, YOU MUST STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase. Tell the user:
-
-> "Cannot run /deploy: no Deployment page found at wiki/Deployment.md. Run /curate-wiki to generate it from the codebase."
-
-Then stop. Do nothing else. MUST NOT attempt to merge PRs, trigger builds, or figure out the steps on your own.
-
-## Process (only if Deployment page exists)
-
-This command IS the user's approval to deploy. Execute all steps without stopping to ask for confirmation.
-
-1. Follow the steps defined in the **Deploy** section of `wiki/Deployment.md`. When the wiki uses shell operators (`&&`, `;`, `|`, `$()`), you MUST split them into separate, single-command Bash calls per `bash-simplicity`. One command per call, no exceptions.
-2. Execute all git and deployment operations. Do not pause between them.
-3. Report what was done at the end
+Use `/stage` instead. See `commands/stage.md` for details.

--- a/plugins/simpleapps/commands/guide.md
+++ b/plugins/simpleapps/commands/guide.md
@@ -38,7 +38,7 @@ Explain the tool boundaries: Basecamp = client-facing, GitHub = developer-facing
 List `repo/plugins/simpleapps/commands/` with `ls repo/plugins/simpleapps/commands/` to enumerate every `*.md` command file. For each file, Read with `limit: 12`. This captures the frontmatter (name, description, allowed-tools) without loading the full body, saving context. Present them in lifecycle order first, then supporting commands:
 
 **Lifecycle** (in pipeline order):
-`/triage` -> `/wip` -> `/investigate` -> `/discuss` -> `/implement` -> `/quality` -> `/sanity-check` -> `/verify` -> `/submit` -> `/deploy` -> `/publish`
+`/triage` -> `/wip` -> `/investigate` -> `/discuss` -> `/implement` -> `/quality` -> `/sanity-check` -> `/verify` -> `/submit` -> `/stage` -> `/publish`
 
 **Supporting** (alphabetical):
 `/audit-augur-packages`, `/commit-message`, `/context-audit`, `/curate-wiki`, `/file-issue`, `/fyxer`, `/guide`, `/project-init`, `/research`, `/wiki`, `/wiki-audit`
@@ -55,7 +55,7 @@ Walk through a concrete example:
 /investigate                     → explore codebase, update WIP with findings
                                  → review the analysis, start coding
 /submit                          → commit and create a PR
-/deploy                          → merge PRs and deploy to staging
+/stage                           → merge PRs and deploy to staging
 /publish                         → version bump, tag, release to production
 ```
 

--- a/plugins/simpleapps/commands/publish.md
+++ b/plugins/simpleapps/commands/publish.md
@@ -15,11 +15,15 @@ Publish a production release by following the **Publish** section of the project
 
 ## Hard Requirement: Deployment Page
 
-Before doing ANYTHING else, read `wiki/Deployment.md` and find the **Publish** section.
+**MUST verify `wiki/Deployment.md` exists before proceeding.** Context compaction can cause the file to drop from memory even if it was read earlier in the session.
 
-**If `wiki/Deployment.md` does not exist or has no Publish section, YOU MUST STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase or version files. Tell the user:
+1. Check if `wiki/Deployment.md` is currently in context from this session
+2. If NOT in context: explicitly `Read wiki/Deployment.md` to reload it
+3. Find the **Publish** section in the page
 
-> "Cannot run /publish: no Deployment page found at wiki/Deployment.md. Run /curate-wiki to generate it from the codebase."
+**If the page is missing or has no Publish section, STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase or version files. Tell the user:
+
+> "Cannot run /publish: `wiki/Deployment.md` is missing or has no Publish section. Run `/curate-wiki` to generate it from the codebase."
 
 Then stop. Do nothing else. MUST NOT attempt to bump versions, tag, or push on your own.
 

--- a/plugins/simpleapps/commands/stage.md
+++ b/plugins/simpleapps/commands/stage.md
@@ -1,0 +1,36 @@
+---
+name: stage
+description: Stage to staging environment. Execute the staging deployment steps from the project wiki Deployment page.
+allowed-tools: Bash(git -C:*), Bash(gh:*), Bash(rm:*), Bash(wc:*), Skill(deployment), Skill(git-safety), Skill(bash-simplicity), Skill(work-habits), Read, Write, Glob, Grep
+---
+
+First, load these skills:
+1. Skill("deployment"): reads wiki Deployment page and loads git-safety
+2. Skill("bash-simplicity"): Bash conventions
+3. Skill("work-habits"): autonomous execution rules and RFC 2119 compliance
+
+## What This Command Does
+
+Stage to staging by following the **Deploy** section of the project's `wiki/Deployment.md` page.
+
+## Hard Requirement: Deployment Page
+
+**MUST verify `wiki/Deployment.md` exists before proceeding.** Context compaction can cause the file to drop from memory even if it was read earlier in the session.
+
+1. Check if `wiki/Deployment.md` is currently in context from this session
+2. If NOT in context: explicitly `Read wiki/Deployment.md` to reload it
+3. Find the **Deploy** section in the page
+
+**If the page is missing or has no Deploy section, STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase. Tell the user:
+
+> "Cannot run /stage: `wiki/Deployment.md` is missing or has no Deploy section. Run `/curate-wiki` to generate it from the codebase."
+
+Then stop. Do nothing else. MUST NOT attempt to merge PRs, trigger builds, or figure out the steps on your own.
+
+## Process (only if Deployment page exists)
+
+This command IS the user's approval to stage. Execute all steps without stopping to ask for confirmation.
+
+1. Follow the steps defined in the **Deploy** section of `wiki/Deployment.md`. When the wiki uses shell operators (`&&`, `;`, `|`, `$()`), you MUST split them into separate, single-command Bash calls per `bash-simplicity`. One command per call, no exceptions.
+2. Execute all git and deployment operations. Do not pause between them.
+3. Report what was done at the end

--- a/plugins/simpleapps/commands/submit.md
+++ b/plugins/simpleapps/commands/submit.md
@@ -18,11 +18,15 @@ Submit the current work for review by following the **Submit** section of the pr
 
 ## Hard Requirement: Deployment Page
 
-Before doing ANYTHING else, read `wiki/Deployment.md` and find the **Submit** section.
+**MUST verify `wiki/Deployment.md` exists before proceeding.** Context compaction can cause the file to drop from memory even if it was read earlier in the session.
 
-**If `wiki/Deployment.md` does not exist or has no Submit section, YOU MUST STOP IMMEDIATELY.** Do not guess, do not improvise, do not use defaults. Tell the user:
+1. Check if `wiki/Deployment.md` is currently in context from this session
+2. If NOT in context: explicitly `Read wiki/Deployment.md` to reload it
+3. Find the **Submit** section in the page
 
-> "Cannot run /submit: no Deployment page found at wiki/Deployment.md. Run /curate-wiki to generate it from the codebase."
+**If the page is missing or has no Submit section, STOP IMMEDIATELY.** Do not guess, do not improvise, do not use defaults. Tell the user:
+
+> "Cannot run /submit: `wiki/Deployment.md` is missing or has no Submit section. Run `/curate-wiki` to generate it from the codebase."
 
 Then stop. Do nothing else. MUST NOT attempt to commit, create PRs, or figure out the steps on your own.
 

--- a/plugins/simpleapps/rules/bash-simplicity.md
+++ b/plugins/simpleapps/rules/bash-simplicity.md
@@ -1,10 +1,13 @@
 # Bash Simplicity
 
+**Always prefer dedicated tools over Bash.** Use Read, Edit, or Write first. Only use Bash for search, build, test, git, and system commands.
+
 The Bash tool already captures stdout, stderr, and exit codes. NEVER add shell plumbing: no `;`, `&&`, `|`, `$()`, `2>&1`, `echo $?`, `node -e`, or `python -c`. If the command contains any of these, it is wrong. One command per call.
 
 MUST use dedicated tools instead of shell commands when one exists:
 - Read files → Read tool (not `cat`, `head`, `tail`)
 - Edit files → Edit tool (not `sed`, `awk`)
+- JSON field extraction → `jq '.field' file.json`
 - Write files → Write tool (not `echo >`, `cat <<EOF`)
 
 Claude Code 2.1.117 removed the Grep and Glob tools. Search files via Bash:

--- a/plugins/simpleapps/rules/workflow.md
+++ b/plugins/simpleapps/rules/workflow.md
@@ -1,5 +1,5 @@
 # Workflow
 
-Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /deploy → /publish. Each step feeds the next. Most daily work ends at /submit. /deploy and /publish are less frequent. /publish requires explicit version verification.
+Follow the development lifecycle: /triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /stage → /publish. Each step feeds the next. Most daily work ends at /submit. /stage and /publish are less frequent. /publish requires explicit version verification.
 
 Load Skill("workflow") for the full development lifecycle and Basecamp-to-GitHub flow.

--- a/plugins/simpleapps/skills/bash-simplicity/SKILL.md
+++ b/plugins/simpleapps/skills/bash-simplicity/SKILL.md
@@ -6,6 +6,27 @@ user-invocable: false
 
 # Bash Simplicity
 
+## Tool Priority Order
+
+**Always use the highest-priority tool that can accomplish the task:**
+
+| Priority | Tool | When to use | Example |
+|----------|------|-------------|---------|
+| 1 | **Read** | Read file contents | `Read(file_path: "...")` |
+| 2 | **Edit** | Edit file contents | `Edit(file_path: "...", ...)` |
+| 3 | **Write** | Write/create files | `Write(file_path: "...", content: "...")` |
+| 4 | **Bash** | Search, build, test, git | `pnpm test`, `grep -rn` |
+
+**If a dedicated tool exists for your task, DO NOT use Bash.** The Read, Edit, and Write tools are:
+- Faster (no permission prompts)
+- Safer (no shell escaping issues)
+- Cleaner (better output formatting)
+
+Only use Bash when:
+- No dedicated tool exists (grep for search, find for file discovery, git for version control)
+- You need to run build tools, test runners, or package managers
+- You need system commands (e.g., `date`, `ls`)
+
 ## Why This Matters
 
 A complex command feels efficient: do more in one call. But the more complex the command, the higher the probability it triggers a permission prompt. A permission prompt blocks the agent until the user responds. If the user doesn't see it for an hour, that hour is lost.
@@ -50,6 +71,13 @@ Dedicated tools are faster, require no permission, and produce better output. MU
 | `cat`, `head`, `tail` | Read tool |
 | `sed`, `awk` | Edit tool |
 | `echo >`, `cat <<EOF` | Write tool |
+| Large JSON file (Read) | `jq '.field' file.json` for field extraction |
+
+**When to use each tool:**
+
+| Use jq | Use Read | Use grep |
+|--------|----------|----------|
+| Extract specific fields from large JSON files | Small JSON files, unknown structure, or malformed JSON | Cross-file string search; not JSON-aware |
 
 **Search is now Bash-only.** Claude Code 2.1.117 removed the dedicated Grep and Glob tools. Search files with one of:
 

--- a/plugins/simpleapps/skills/deployment/SKILL.md
+++ b/plugins/simpleapps/skills/deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deployment
-description: Project deployment conventions. Reads the wiki Deployment page and executes submit, deploy, or publish steps. Refuses to operate without a Deployment page.
+description: Project deployment conventions. Reads the wiki Deployment page and executes submit, stage, or publish steps. Refuses to operate without a Deployment page.
 user-invocable: false
 allowed-tools:
   - Read
@@ -10,7 +10,7 @@ allowed-tools:
   - Skill(git-safety)
 ---
 
-First, use Skill("git-safety") to load git guardrails. The shipping commands (`/submit`, `/deploy`, `/publish`) load `conventional-commits` and `github` directly when they need them. This skill does not pre-load them.
+First, use Skill("git-safety") to load git guardrails. The shipping commands (`/submit`, `/stage`, `/publish`) load `conventional-commits` and `github` directly when they need them. This skill does not pre-load them.
 
 # Deployment
 
@@ -35,17 +35,32 @@ Not all projects need all three. Client sites may only have Submit and Deploy. P
 
 ## How It Works
 
-1. Read `wiki/Deployment.md`
-2. Find the section matching the requested action (Submit, Deploy, or Publish)
-3. If the page or section is missing, **refuse to operate**. Tell the user to run `/curate-wiki` to generate it.
-4. Execute the steps in that section
+1. Check if `wiki/Deployment.md` is in context (from previous reads this session)
+2. If NOT in context, explicitly read `wiki/Deployment.md` using the Read tool
+3. Find the section matching the requested action (Submit, Deploy, or Publish)
+4. If the page or section is missing, **refuse to operate**. Tell the user to run `/curate-wiki` to generate it.
+5. Execute the steps in that section
+
+## Critical: Deployment Page Must Exist
+
+**MUST verify `wiki/Deployment.md` exists before proceeding.** Context compaction can cause the file to drop from memory even if it was read earlier in the session. Before any deployment action, check:
+
+1. Is `wiki/Deployment.md` currently in context from this session?
+2. If NO: use `Read` to load `wiki/Deployment.md` explicitly
+3. If YES: proceed
+
+**If the Read tool returns empty or the page is missing, STOP IMMEDIATELY.** Do not guess, do not improvise, do not infer steps from the codebase. Tell the user:
+
+> "Cannot read `wiki/Deployment.md`. This file is required for /submit, /stage, and /publish to work. Run `/curate-wiki` to generate it from the codebase."
+
+Then stop. Do nothing else.
 
 ## Command approval model
 
 The user invoking a command IS the approval to execute all its steps, including git writes. Do not stop to ask for confirmation mid-execution.
 
 - `/submit`: execute all steps (commit, push, PR). Report at the end.
-- `/deploy`: execute all steps. Report at the end.
+- `/stage`: execute all steps. Report at the end.
 - `/publish`: **EXCEPTION**. Must complete the verification gate below and get secondary confirmation BEFORE executing any publish steps. This is the only command that pauses for approval.
 
 ## Guard Rails

--- a/plugins/simpleapps/skills/git-safety/SKILL.md
+++ b/plugins/simpleapps/skills/git-safety/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-safety
-description: This skill should be used when the user asks to "commit", "push", "tag", "merge", "rebase", "branch -D", "stash", or invokes /submit, /deploy, /publish. Also load when editing git safety rules or reviewing git workflow. Provides comprehensive guardrails for safe git operations.
+description: This skill should be used when the user asks to "commit", "push", "tag", "merge", "rebase", "branch -D", "stash", or invokes /submit, /stage, /publish. Also load when editing git safety rules or reviewing git workflow. Provides comprehensive guardrails for safe git operations.
 user-invocable: false
 ---
 
@@ -23,7 +23,7 @@ Every git push, every PR, every wiki edit that hits GitHub is done under the use
 The user gives approval in one of two ways:
 
 1. **Direct instruction**: the user says "commit", "push", "tag", or equivalent
-2. **Shipping commands**: the user invokes `/submit`, `/deploy`, or `/publish`. Invoking the command IS the approval for the git operations defined in that command's workflow.
+2. **Shipping commands**: the user invokes `/submit`, `/stage`, or `/publish`. Invoking the command IS the approval for the git operations defined in that command's workflow.
 
 ### Approval is scoped, not blanket
 

--- a/plugins/simpleapps/skills/wiki/SKILL.md
+++ b/plugins/simpleapps/skills/wiki/SKILL.md
@@ -201,7 +201,7 @@ The wikis are kept fresh by `/curate-wiki` runs across projects. Searching local
 
 ## Deployment Page
 
-Every project wiki MUST have a `Deployment.md` page with up to three sections: Submit, Deploy, and Publish. This page defines the project-specific steps that `/submit`, `/deploy`, and `/publish` commands execute. Run `/curate-wiki` to generate it from the codebase. The command scans CI workflows, package.json, deploy scripts, and asks the user about anything it cannot determine. See the `deployment` skill for the expected format.
+Every project wiki MUST have a `Deployment.md` page with up to three sections: Submit, Deploy, and Publish. This page defines the project-specific steps that `/submit`, `/stage`, and `/publish` commands execute. Run `/curate-wiki` to generate it from the codebase. The command scans CI workflows, package.json, deploy scripts, and asks the user about anything it cannot determine. See the `deployment` skill for the expected format.
 
 ## Testing Page
 

--- a/plugins/simpleapps/skills/workflow/SKILL.md
+++ b/plugins/simpleapps/skills/workflow/SKILL.md
@@ -69,7 +69,7 @@ gh issue create --repo simpleapps-com/<repo> \
 The full workflow from task to delivery, each step feeding the next:
 
 ```
-/triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /deploy → /publish
+/triage → /wip → /investigate → /discuss → /implement → /quality → /sanity-check → /verify → /submit → /stage → /publish
 ```
 
 | Phase | Command | What happens |
@@ -83,12 +83,12 @@ The full workflow from task to delivery, each step feeding the next:
 | Solution audit | `/sanity-check` | Did we solve the right problem without commission/omission errors? |
 | Browser checks | `/verify` | Walk through wiki's Testing.md checklist in Chrome |
 | Submit | `/submit` | Commit and create a PR for review |
-| Stage | `/deploy` | Deploy to staging (merge PRs, trigger staging build) |
+| Stage | `/stage` | Deploy to staging (merge PRs, trigger staging build) |
 | Release | `/publish` | Version bump, tag, release to production (with verification) |
 
-Not every task uses all steps. Most daily work ends at `/submit`. `/deploy` and `/publish` are used less frequently. `/publish` is intentionally rare and requires explicit verification of the exact version going to production.
+Not every task uses all steps. Most daily work ends at `/submit`. `/stage` and `/publish` are used less frequently. `/publish` is intentionally rare and requires explicit verification of the exact version going to production.
 
-The three shipping commands (`/submit`, `/deploy`, `/publish`) read project-specific steps from `wiki/Deployment.md`. They refuse to operate if the Deployment page is missing. Run `/curate-wiki` to generate it from the codebase.
+The three shipping commands (`/submit`, `/stage`, `/publish`) read project-specific steps from `wiki/Deployment.md`. They refuse to operate if the Deployment page is missing. Run `/curate-wiki` to generate it from the codebase.
 
 Commands like `/research` and `/discuss` can be used at any stage. `/quality`, `/verify`, `/curate-wiki`, and `/wiki-audit` can run independently.
 

--- a/tmp/commit-msg.txt
+++ b/tmp/commit-msg.txt
@@ -1,0 +1,8 @@
+chore: rename /deploy to /stage and fix context compaction issues
+
+- Renamed /deploy command to /stage for semantic clarity (staging not production)
+- Added context compaction fixes to submit, deploy, publish commands
+  - Check if wiki/Deployment.md is in context before operating
+  - Explicitly reload if dropped from memory
+- Added Tool Priority Order section to bash-simplicity skill
+- Updated all references from /deploy to /stage across commands, skills, rules, and wiki


### PR DESCRIPTION
chore: rename /deploy to /stage and fix context compaction issues

## What Changed

- Renamed `/deploy` command to `/stage` for semantic clarity (deploys to staging, not production)
- Added context compaction fixes to submit, deploy, publish commands
  - Check if `wiki/Deployment.md` is in context before operating
  - Explicitly reload if dropped from memory (fixes false "file not found" errors)
- Added Tool Priority Order section to bash-simplicity skill
  - Emphasizes Read/Edit/Write should be used BEFORE Bash commands
- Updated all references from `/deploy` to `/stage` across commands, skills, rules, and wiki

## Testing

- Typecheck: PASSED
- Tests: 33 passed

## Related

Fixes #58 (chore: rename /deploy to /stage for clarity)